### PR TITLE
Configure `arduino/arduino-lint-action` to Library Manager "update" mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,3 +28,5 @@ jobs:
       # Runs a single command using the runners shell
       - name: arduino/arduino-lint-action
         uses: arduino/arduino-lint-action@v1.0.1
+        with:
+          library-manager: update


### PR DESCRIPTION
[The `arduino/arduino-lint-action` GitHub Actions action](https://github.com/arduino/arduino-lint-action) offers a set of checks for the additional requirements specific to the Arduino Library Manager index.

There are differences in these requirements depending on whether the library is already in the index. By default, these checks are in the "submit" mode, where the library is checked for compliance with [the requirements to be accepted into the Library Manager index](https://github.com/arduino/library-registry/blob/main/FAQ.md#what-are-the-requirements-for-a-library-to-be-added-to-library-manager). Once the library has been accepted, [the action's configuration](https://github.com/arduino/arduino-lint-action#library-manager) must be adjusted to the "update" mode, where it is checked for [the requirements for a new release of a library already in the Library Manager index to be added](https://github.com/arduino/library-registry/blob/main/FAQ.md#what-are-the-requirements-for-publishing-new-releases-of-libraries-already-in-the-library-manager-list).

The library has now been added to the Library Manager index (https://github.com/arduino/library-registry/pull/1717), but the action still had the default "submit" configuration, which resulted in [a spurious workflow run failure](https://github.com/E-Lagori/ELi_McM_4_00/runs/7871769827?check_suite_focus=true#step:3:16) due to violation of [rule **LP017**](https://arduino.github.io/arduino-lint/latest/rules/library/#duplicate-name-lp017). Reconfiguring the action to "update" mode will cause the action to provide accurate results.